### PR TITLE
I've aligned my work plans with the PRDv2 V1 scope.

### DIFF
--- a/docs/work_plans/AGENT-V1-STORY-002.md
+++ b/docs/work_plans/AGENT-V1-STORY-002.md
@@ -26,12 +26,13 @@ Integrate the native Genkit Google AI plugin to call a Gemini model (targeting "
 1.  **Configure Google AI Plugin:** Ensure the `@genkit-ai/googleai` plugin is configured in `genkit.config.ts` and potentially initialized with the project ID.
 2.  **Select Model:** Define which Gemini model to use for the Storyteller (e.g., `gemini-1.5-flash-latest`). Make this configurable via `src/config/config.ts` or environment variables.
 3.  **Develop Basic Prompts:** Create initial prompt structures within the flow for different scenarios:
-    *   Processing a player's voice/text input: Include context (current scene, recent events, player character info), the player's input, and instructions to generate the GM's response/narration and potentially identify needed state changes.
-    *   Interpreting a dice roll result: Include context, the action attempted, the dice result, and instructions to narrate the outcome based on the ruleset/situation.
-    *   Generating NPC dialogue (V1: To be spoken by Narrator voice): Include NPC persona, context, and instructions for dialogue.
+    *   Processing a `voiceResult` payload (containing results from the Bot's Gemini Live API interaction): Include context (current scene, recent events, player character info), the final user transcript, and Gemini's text response from the Live API turn. Instruct the Storyteller's Gemini call to perform any necessary *secondary processing* (e.g., extract entities for game state, determine subtle consequences, log a summary for the Planner). In some cases, if the Live API interaction provided sufficient textual output for the bot, an LLM call in the Storyteller might not be needed for this payload type.
+    *   Processing a `textMessage` input: Include context, the player's text input, and instructions to generate the GM's response/narration.
+    *   Interpreting a `diceResult` input: Include context, the action attempted, the dice result, and instructions to narrate the outcome.
+    *   Generating NPC dialogue (V1: To be spoken by Narrator voice via Live API): If a separate NPC dialogue generation step is needed within the Storyteller flow (e.g., if the initial Live API turn didn't cover it), include NPC persona, context, and instructions for dialogue. The output text would then be sent back to the bot, which would use the Live API for TTS in the *next* interaction.
 4.  **Integrate `generate` Call:**
     *   Import `generate` from `@genkit-ai/core` and the specific model reference (e.g., `gemini15Flash`) from `@genkit-ai/googleai`.
-    *   Within the flow logic (e.g., inside the `switch` statement from AGENT-V1-STORY-001), construct the appropriate prompt based on the input type.
+    *   Within the flow logic (e.g., inside the `switch` statement from AGENT-V1-STORY-001), construct the appropriate prompt based on the input type and the considerations above. If an LLM call is needed for the specific payload type:
     *   Call `await generate({ model: config.storytellerModel, prompt: constructedPrompt, config: { temperature: 0.7 /* etc */ } })`.
     *   Process the response: Extract the generated text content.
 5.  **Update Flow Output:** Modify the flow's return value to potentially include the generated text, though for V1 the primary output channel is the Live Voice API managed by the Bot. The main goal here is internal processing and state update preparation.

--- a/docs/work_plans/DISCORD-V1-002.md
+++ b/docs/work_plans/DISCORD-V1-002.md
@@ -17,7 +17,7 @@ Integrate the Google Live Voice API into the Discord Bot. The bot needs to manag
 *   `src/discord/liveVoiceHandler.ts` (New module)
 *   `src/discord/bot.ts` (Event listeners for voice state, potentially commands)
 *   `discord.js` (Voice channel management, audio streams)
-*   Google Live Voice API Client (Node.js SDK or custom implementation for streaming API)
+*   Google Live Voice API Client (Node.js, likely direct WebSocket implementation for `wss://generativelanguage.googleapis.com/.../BidiGenerateContent` endpoint, or verify if `@google/generative-ai` SDK adequately supports this specific audio streaming use case)
 *   `@discordjs/voice` library (For managing Discord voice connections and streams)
 *   `src/config/config.ts` (API keys/endpoints for Live Voice API)
 *   `src/utils/logger.ts`
@@ -30,7 +30,8 @@ Integrate the Google Live Voice API into the Discord Bot. The bot needs to manag
     *   Manage the voice connection state (`VoiceConnection`).
 3.  **Audio Streaming (Discord -> Live Voice API):**
     *   Once connected, get the audio stream (`receiver.subscribe`) for a user (or potentially combined stream, TBD based on API needs).
-    *   Set up the connection to the Google Live Voice API endpoint (using its SDK/protocol).
+    *   Set up the WebSocket connection to the Gemini Live API endpoint (e.g., `wss://generativelanguage.googleapis.com/ws/.../BidiGenerateContent`). This may involve direct WebSocket client usage if the standard `@google/generative-ai` SDK does not fully support the required audio streaming and message exchange protocol for `BidiGenerateContent`.
+    *   Investigate and confirm the audio encoding format(s) (e.g., LINEAR16, Opus) accepted by the Gemini Live API for the `audio` field in `BidiGenerateContentRealtimeInput`. Implement transcoding from Discord's Opus stream if necessary.
     *   Pipe/forward the Opus audio stream from Discord (potentially needing transcoding if the API requires a different format like LINEAR16) to the Live Voice API input stream.
 4.  **Audio Streaming (Live Voice API -> Discord):**
     *   Receive the audio stream output from the Live Voice API.
@@ -93,8 +94,8 @@ Lead Engineer (self)
 
 ## Questions / Uncertainties
 
-*   **Availability & Interface of Live Voice API Node.js Client:** Does a dedicated Node.js streaming client exist? If not, implementing the bidirectional gRPC/REST streaming protocol manually adds significant complexity.
-*   **Audio Format Compatibility:** Does the Live Voice API accept Discord's Opus format directly, or is transcoding required? Transcoding adds complexity and latency.
+*   **Availability & Interface of Live Voice API Node.js Client:** Confirm if the standard `@google/generative-ai` Node.js client directly supports the stateful, bidirectional audio streaming over WebSockets required by the Gemini Live API (`BidiGenerateContent`), or if direct WebSocket client implementation is necessary. Clarify the exact message schema and lifecycle management (e.g., handling `BidiGenerateContentSetup`, `RealtimeInput`, `ServerContent` messages).
+*   **Audio Format Compatibility:** **Crucially, determine if the Gemini Live API accepts Discord's Opus format directly for the `audio` field in `BidiGenerateContentRealtimeInput`.** If not, transcoding (e.g., to LINEAR16) is required, adding complexity and latency. This needs to be confirmed during initial implementation.
 *   **API Authentication:** Exact mechanism for authenticating the streaming API call (API Key? ADC with SA?).
 *   **Interaction Turn Detection:** How reliably does the API signal the end of a user's utterance and the availability of the final transcript?
 *   **Handling Multiple Users:** Does the bot need to handle simultaneous speakers or manage separate streams per user? (Assume single active stream focus for V1 simplifies). Needs clarification based on API capabilities.

--- a/docs/work_plans/INFRA-V1-001.md
+++ b/docs/work_plans/INFRA-V1-001.md
@@ -65,6 +65,7 @@ Set up the foundational Infrastructure as Code (IaC) using Terraform to manage c
     *   [ ] Define a `google_artifact_registry_repository` resource (e.g., format DOCKER, name `discord-bot-repo`).
 *   [ ] In `infra/main.tf` (or a dedicated `secrets.tf`):
     *   [ ] Define `google_secret_manager_secret` resources for planned secrets (e.g., `discord-bot-token`). **Do not define `google_secret_manager_secret_version` here.**
+    *   [ ] <!-- (Optional) Define placeholder for OPENAI_API_KEY if future use is anticipated: google_secret_manager_secret for OPENAI_API_KEY. Note: Not required for PRDv2 V1. -->
 *   [ ] Create `infra/outputs.tf` (e.g., output Artifact Registry repository URL).
 *   [ ] Run `terraform fmt` to format the code.
 *   [ ] Run `terraform validate` to check syntax.

--- a/docs/work_plans/INFRA-V1-002.md
+++ b/docs/work_plans/INFRA-V1-002.md
@@ -49,7 +49,7 @@ Extend the Terraform configuration to define the core application infrastructure
     *   [ ] Define `google_project_iam_member` or `google_project_iam_binding` resources to grant roles:
         *   `storyteller-sa`: `roles/datastore.user`, `roles/logging.logWriter`, `roles/monitoring.metricWriter`, `roles/cloudtrace.agent`, `roles/secretmanager.secretAccessor`, `roles/aiplatform.user`.
         *   `planner-sa`: `roles/datastore.user`, `roles/logging.logWriter`, `roles/monitoring.metricWriter`, `roles/cloudtrace.agent`, `roles/secretmanager.secretAccessor`, `roles/aiplatform.user`, `roles/eventarc.eventReceiver`.
-        *   `discord-bot-sa`: `roles/run.invoker` (on storyteller function), `roles/iam.serviceAccountTokenCreator`, `roles/secretmanager.secretAccessor`, `roles/logging.logWriter` (plus any roles needed for Live Voice API - TBD).
+        *   `discord-bot-sa`: `roles/run.invoker` (on storyteller function), `roles/iam.serviceAccountTokenCreator` (to generate identity tokens for calling Storyteller), `roles/secretmanager.secretAccessor`, `roles/logging.logWriter` (plus specific IAM permissions required for accessing the **Gemini Live API / `generativelanguage.googleapis.com` WebSocket endpoint** - to be determined during DISCORD-V1-002 implementation).
 *   **Cloud Functions (`infra/functions.tf`):**
     *   [ ] Define `google_cloudfunctions2_function` for `storyteller-flow`:
         *   `location = var.region`


### PR DESCRIPTION
I made modifications to specific work plans to ensure consistency with docs/product_requirements_v2.md, primarily focusing on:
- Clarifying Storyteller's use of Gemini post-Live API interaction (AGENT-V1-STORY-002.md).
- Emphasizing WebSocket nature and audio format investigation for Gemini Live API integration in the Discord bot (DISCORD-V1-002.md).
- Commenting out non-V1 secret placeholders (INFRA-V1-001.md).
- Refining TBD IAM permission descriptions for Gemini Live API (INFRA-V1-002.md).

I found most other work plans to be already well-aligned.